### PR TITLE
[package.xml] add glog as dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
  
+  <depend>libgoogle-glog-dev</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>image_transport</depend>
   <depend>image_geometry</depend>


### PR DESCRIPTION
This allows to install 3rd party libs with rosdep after cloning the code, e.g.

```
rosdep install -i --from-path ~/work/ros_ws
```

`libgoogle-glog-dev` was the only system dependency that was missing on my system. Maybe on a clean Ubuntu install more is needed. But maybe as you noted in the Readme all of that is covered by the ROS dependencies transitively. One would need to try on a clean install.
